### PR TITLE
Add programs page with generic card grid

### DIFF
--- a/frontend/src/app/programs/page.tsx
+++ b/frontend/src/app/programs/page.tsx
@@ -1,9 +1,49 @@
-import React from 'react';
+'use client';
 
-type Props = {};
+import { useState } from 'react';
+import { useFetch } from '@/hooks/useFetch';
 
-const page = (props: Props) => {
-  return <div>программы</div>;
-};
+import SearchInput from '@/components/ui/SearchInput/SearchInput';
+import ViewSwitcher from '@/components/ui/ViewSwitcher/ViewSwitcher';
+import ProgramsGrid from '@/components/ui/ProgramsGrid/ProgramsGrid';
 
-export default page;
+import type { ProgramApi } from '@/types';
+import styles from '../app.module.css';
+
+export default function ProgramsPage() {
+  const [search, setSearch] = useState('');
+  const [view, setView] = useState<'list' | 'grid'>('list');
+  const { data, loading, error } = useFetch<ProgramApi>('/programs');
+
+  const programs = data || [];
+  const filtered = programs.filter((p) => {
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      return (
+        p.title.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q)
+      );
+    }
+    return true;
+  });
+
+  return (
+    <>
+      <div className='container'>
+        <SearchInput value={search} onChange={setSearch} />
+      </div>
+
+      <div className={styles.eventsContainer}>
+        <header className={styles.eventsHeader}>
+          <h2>Список программ</h2>
+          <ViewSwitcher viewMode={view} onViewChange={setView} />
+        </header>
+
+        {loading && <p>Загрузка…</p>}
+        {!loading && !error && (
+          <ProgramsGrid programs={filtered as ProgramApi[]} viewMode={view} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/ui/CardGrid/CardGrid.module.css
+++ b/frontend/src/components/ui/CardGrid/CardGrid.module.css
@@ -1,0 +1,17 @@
+.grid {
+  max-width: 100%;
+}
+
+.gridView {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+
+  column-gap: 16px;
+  row-gap: 12px;
+}
+
+.listView {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/frontend/src/components/ui/CardGrid/CardGrid.tsx
+++ b/frontend/src/components/ui/CardGrid/CardGrid.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React from 'react';
+import styles from './CardGrid.module.css';
+
+export interface CardGridProps<T> {
+  items: T[];
+  viewMode: 'grid' | 'list';
+  renderItem: (item: T, index: number) => React.ReactNode;
+  className?: string;
+}
+
+export default function CardGrid<T>({
+  items,
+  viewMode,
+  renderItem,
+  className,
+}: CardGridProps<T>) {
+  if (!items.length) return <p>пока что данных нет</p>;
+
+  return (
+    <div
+      className={`${styles.grid} ${
+        viewMode === 'grid' ? styles.gridView : styles.listView
+      } ${className ?? ''}`}
+    >
+      {items.map((item, idx) => (
+        <React.Fragment key={idx}>{renderItem(item, idx)}</React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/EventsGrid/EventsGrid.tsx
+++ b/frontend/src/components/ui/EventsGrid/EventsGrid.tsx
@@ -2,6 +2,7 @@
 
 import type { Event } from '@prisma/client';
 import EventCard from '@/components/ui/EventCard/EventCard';
+import CardGrid from '../CardGrid/CardGrid';
 import styles from './EventsGrid.module.css';
 
 interface Props {
@@ -10,17 +11,12 @@ interface Props {
 }
 
 export default function EventsGrid({ events, viewMode }: Props) {
-  if (!events.length) return <p>пока что событий нет</p>;
-
   return (
-    <div
-      className={`${styles.events} ${
-        viewMode === 'grid' ? styles.eventsGrid : styles.eventsList
-      }`}
-    >
-      {events.map((p) => (
-        <EventCard key={p.id} event={p} viewMode={viewMode} />
-      ))}
-    </div>
+    <CardGrid
+      items={events}
+      viewMode={viewMode}
+      className={styles.events}
+      renderItem={(p) => <EventCard key={p.id} event={p} viewMode={viewMode} />}
+    />
   );
 }

--- a/frontend/src/components/ui/ProgramCard/ProgramCard.module.css
+++ b/frontend/src/components/ui/ProgramCard/ProgramCard.module.css
@@ -1,0 +1,37 @@
+.card {
+  display: flex;
+  flex-direction: column;
+
+  background-color: var(--color-content-main);
+  max-width: 100%;
+  color: var(--color-home-white);
+  border-radius: var(--radius-medium);
+  gap: 10px;
+}
+
+.image {
+  border-radius: var(--radius-medium);
+  object-fit: cover;
+  height: 90px;
+  max-width: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 16px;
+  gap: 18px;
+  flex-grow: 1;
+}
+
+.contentMain {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.title {
+  word-wrap: break-word;
+}

--- a/frontend/src/components/ui/ProgramCard/ProgramCard.tsx
+++ b/frontend/src/components/ui/ProgramCard/ProgramCard.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import styles from './ProgramCard.module.css';
+import type { ProgramApi } from '@/types';
+
+interface Props {
+  program: ProgramApi;
+  viewMode: 'grid' | 'list';
+}
+
+export default function ProgramCard({ program, viewMode }: Props) {
+  const cover = (program as any).coverUrl || 'https://placehold.co/600x400';
+
+  return (
+    <article
+      className={`${styles.card} ${
+        viewMode === 'grid' ? styles.cardGrid : styles.cardList
+      }`}
+    >
+      <Image
+        className={styles.image}
+        src={cover}
+        width={600}
+        height={400}
+        alt=''
+      />
+      <div className={styles.content}>
+        <div className={styles.contentMain}>
+          <h3 className={`${styles.title} font-body-normal-bold`}>
+            {program.title}
+          </h3>
+          {program.startDate && (
+            <p className='font-body-normal'>
+              Старт: {new Date(program.startDate).toLocaleDateString('ru-RU')}
+            </p>
+          )}
+          {program.durationWeeks && (
+            <p className='font-body-normal'>
+              Длительность: {program.durationWeeks} недель
+            </p>
+          )}
+          {program.priceRub && (
+            <p className='font-body-normal'>Цена: {program.priceRub.toString()} ₽</p>
+          )}
+        </div>
+        <Link className='button-small' href={`/programs/${program.slug}`}>
+          Подробнее
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ui/ProgramsGrid/ProgramsGrid.module.css
+++ b/frontend/src/components/ui/ProgramsGrid/ProgramsGrid.module.css
@@ -1,0 +1,17 @@
+.events {
+  max-width: 100%;
+}
+
+.eventsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+
+  column-gap: 16px;
+  row-gap: 12px;
+}
+
+.eventsList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/frontend/src/components/ui/ProgramsGrid/ProgramsGrid.tsx
+++ b/frontend/src/components/ui/ProgramsGrid/ProgramsGrid.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { ProgramApi } from '@/types';
+import ProgramCard from '@/components/ui/ProgramCard/ProgramCard';
+import CardGrid from '../CardGrid/CardGrid';
+import styles from './ProgramsGrid.module.css';
+
+interface Props {
+  programs: ProgramApi[];
+  viewMode: 'grid' | 'list';
+}
+
+export default function ProgramsGrid({ programs, viewMode }: Props) {
+  return (
+    <CardGrid
+      items={programs}
+      viewMode={viewMode}
+      className={styles.events}
+      renderItem={(p) => <ProgramCard key={p.id} program={p} viewMode={viewMode} />}
+    />
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,9 @@
-import type { Event as EventDB } from '@prisma/client';
+import type { Event as EventDB, Program as ProgramDB } from '@prisma/client';
 // FIXME: зачем?
 export interface EventApi extends Omit<EventDB, 'images'> {
   coverUrl: string | null;
+}
+
+export interface ProgramApi extends ProgramDB {
+  coverUrl?: string | null;
 }


### PR DESCRIPTION
## Summary
- create generic `CardGrid` component
- add `ProgramCard` and `ProgramsGrid`
- implement `/programs` page using shared layout
- extend shared `types` for program API
- refactor `EventsGrid` to reuse `CardGrid`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845aec2dff8832786a6f3812c176fc1