### PR TITLE
Add signup modal

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "bcrypt-ts": "^7.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "cookie-parser": "^1.4.7",
     "dayjs": "^1.11.13",
     "helmet": "^7.0.0",
     "passport": "^0.6.0",

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,19 +1,28 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import { AuthService } from './auth.service';
-import { AuthController } from './auth.controller';
-import { JwtStrategy } from './jwt.strategy';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
 import { PrismaModule } from '../database/prisma.module';
 import { UsersModule } from '../users/users.module';
 
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtStrategy } from './jwt.strategy';
+
 @Module({
   imports: [
+    ConfigModule,
     PrismaModule,
     UsersModule,
     PassportModule,
     JwtModule.registerAsync({
-      useFactory: () => ({ secret: process.env.JWT_SECRET, signOptions: { expiresIn: '15m' } }),
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '15m' },
+      }),
     }),
   ],
   providers: [AuthService, JwtStrategy],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { Reflector } from '@nestjs/core';
 import { ClassSerializerInterceptor } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,6 +14,7 @@ async function bootstrap() {
     credentials: true,
   });
 
+  app.use(cookieParser());
   app.use(helmet());
   app.useGlobalPipes(
     new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),

--- a/frontend/src/app/details/EventDetails.tsx
+++ b/frontend/src/app/details/EventDetails.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import Image from 'next/image';
+import { useState } from 'react';
 import styles from './Details.module.css';
 
 import type { EventApi } from '@/types';
 import LinkIcon from '@/components/icons/LinkIcon/LinkIcon';
+import SignUpModal from '@/components/ui/SignUpModal/SignUpModal';
+import api from '@/lib/api';
 
 export default function EventDetails({
   data,
@@ -13,6 +16,15 @@ export default function EventDetails({
   data: EventApi;
   onBack: () => void;
 }) {
+  const [open, setOpen] = useState(false);
+
+  const handleConfirm = async () => {
+    try {
+      await api.post('/applications', { eventId: data.id });
+    } finally {
+      setOpen(false);
+    }
+  };
   return (
     <>
       <div className={`${styles.header} container`}>
@@ -67,7 +79,15 @@ export default function EventDetails({
             </div>
           )}
         </div>
-        <button className='button-large'>Записаться</button>
+        <button className='button-large' onClick={() => setOpen(true)}>
+          Записаться
+        </button>
+        <SignUpModal
+          open={open}
+          title={data.title}
+          onConfirm={handleConfirm}
+          onClose={() => setOpen(false)}
+        />
       </div>
     </>
   );

--- a/frontend/src/app/details/ProgramDetails.tsx
+++ b/frontend/src/app/details/ProgramDetails.tsx
@@ -2,10 +2,13 @@
 
 import Image from 'next/image';
 import { ProgramDocument, ProgramFormat, ProgramLevel } from '@prisma/client';
+import { useState } from 'react';
 
 import type { ProgramApi } from '@/types';
 import AccordionBlock from '@/components/ui/AccordionBlock/AccordionBlock';
 import LinkIcon from '@/components/icons/LinkIcon/LinkIcon';
+import SignUpModal from '@/components/ui/SignUpModal/SignUpModal';
+import api from '@/lib/api';
 import styles from './Details.module.css';
 
 export default function ProgramDetails({
@@ -16,6 +19,16 @@ export default function ProgramDetails({
   onBack: () => void;
 }) {
   // FIXME: вынести отсюда чтоле
+  const [open, setOpen] = useState(false);
+
+  const handleConfirm = async () => {
+    try {
+      await api.post('/applications', { programId: data.id });
+    } finally {
+      setOpen(false);
+    }
+  };
+
   const levelLabels: Record<ProgramLevel, string> = {
     [ProgramLevel.BEGINNER]: 'Начальный',
     [ProgramLevel.INTERMEDIATE]: 'Средний',
@@ -113,7 +126,15 @@ export default function ProgramDetails({
             </ul>
           </AccordionBlock>
         </div>
-        <button className='button-large'>Записаться</button>
+        <button className='button-large' onClick={() => setOpen(true)}>
+          Записаться
+        </button>
+        <SignUpModal
+          open={open}
+          title={data.title}
+          onConfirm={handleConfirm}
+          onClose={() => setOpen(false)}
+        />
       </div>
     </>
   );

--- a/frontend/src/components/ui/SignUpModal/SignUpModal.module.css
+++ b/frontend/src/components/ui/SignUpModal/SignUpModal.module.css
@@ -1,0 +1,23 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: var(--color-home-white);
+  padding: 24px;
+  border-radius: var(--radius-large);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 90%;
+}
+
+.text {
+  text-align: center;
+}

--- a/frontend/src/components/ui/SignUpModal/SignUpModal.tsx
+++ b/frontend/src/components/ui/SignUpModal/SignUpModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styles from './SignUpModal.module.css';
+
+interface Props {
+  open: boolean;
+  title: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function SignUpModal({ open, title, onConfirm, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div
+        className={styles.modal}
+        onClick={(e) => e.stopPropagation()}
+        role='dialog'
+        aria-modal='true'
+      >
+        <p className={styles.text}>
+          Вы хотите записаться:
+          <br />
+          <span className='font-body-normal-bold'>{title}</span>
+        </p>
+        <button className='button-large' onClick={onConfirm}>
+          Подтвердить запись
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/UseAuth.tsx
+++ b/frontend/src/hooks/UseAuth.tsx
@@ -46,7 +46,7 @@ export function useAuth() {
       /* сервер может вернуть 401 — игнорируем */
     } finally {
       localStorage.clear();
-      router.push('/login'); // редирект на форму входа
+      router.push('/auth/login'); // редирект на форму входа
     }
   }, [router]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,7 +28,7 @@ api.interceptors.response.use(
       return api.request(err.config);
     } catch {
       localStorage.clear();
-      window.location.href = '/login';
+      window.location.href = '/auth/login';
       throw err;
     }
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,36 +1,63 @@
-import axios from 'axios';
+// api.ts
+import axios, { AxiosError } from 'axios';
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BACKEND,
-  withCredentials: true,
+  withCredentials: true, // браузер будет слать access/refresh куки автоматически
 });
 
-api.interceptors.request.use((cfg) => {
-  cfg.headers['Authorization'] = `Bearer ${localStorage.getItem('token')}`;
-  return cfg;
-});
+/**
+ * ─────────────────────────────────────────────
+ *  REQUEST-ИНТЕРСЕПТОР
+ * ─────────────────────────────────────────────
+ *
+ * Если вы храните токен **только** в http-only cookie,
+ * заголовок Authorization добавлять не нужно ─ убираем его совсем.
+ * (Оставьте интерсептор пустым, если нужно логировать запросы,
+ *  или удалите, если не нужен.)
+ */
+api.interceptors.request.use((cfg) => cfg);
 
+/**
+ * ─────────────────────────────────────────────
+ *  RESPONSE-ИНТЕРСЕПТОР (обновление access-token)
+ * ─────────────────────────────────────────────
+ *
+ * Алгоритм:
+ *  • Любой 401 ⇒ пробуем вызвать /auth/refresh
+ *    (refreshToken уйдёт в cookie).
+ *  • Если /auth/refresh вернул 200 и выставил Set-Cookie
+ *    с новым accessToken, повторяем исходный запрос.
+ *  • Если /auth/refresh тоже 401/403 ⇒ оба токена протухли,
+ *    отправляем пользователя на страницу логина.
+ */
 api.interceptors.response.use(
-  (r) => r,
-  async (err) => {
-    if (err.response?.status !== 401) throw err;
+  (response) => response,
+  async (error: AxiosError) => {
+    // не 401 → отдать ошибку дальше
+    if (error.response?.status !== 401) {
+      throw error;
+    }
 
     try {
-      const { data } = await axios.post(
+      // пытаемся обновить accessToken
+      await axios.post(
         `${process.env.NEXT_PUBLIC_BACKEND}/auth/refresh`,
-        {
-          refreshToken: localStorage.getItem('refresh'),
-        }
+        {}, // тело не нужно, refreshToken в cookie
+        { withCredentials: true } // чтобы куки ушли и Set-Cookie принялся
       );
-      localStorage.setItem('token', data.accessToken);
-      localStorage.setItem('refresh', data.refreshToken);
-      err.config.headers['Authorization'] = `Bearer ${data.accessToken}`;
-      return api.request(err.config);
-    } catch {
-      localStorage.clear();
+
+      // повторяем оригинальный запрос
+      if (error.config) {
+        return api.request(error.config);
+      }
+    } catch (refreshErr) {
+      // refresh не помог → токены недействительны
+      // отправляем на логин (или можете показать модалку)
       window.location.href = '/auth/login';
-      throw err;
     }
+
+    throw error; // пробрасываем исходную ошибку наверх
   }
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "bcrypt-ts": "^7.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "cookie-parser": "^1.4.7",
         "dayjs": "^1.11.13",
         "helmet": "^7.0.0",
         "passport": "^0.6.0",
@@ -8831,6 +8832,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"


### PR DESCRIPTION
## Summary
- add signup modal component
- trigger modal in ProgramDetails and EventDetails pages
- send application request on confirmation

## Testing
- `npm --workspace frontend run lint` *(fails: next lint not found)*

------
https://chatgpt.com/codex/tasks/task_e_684854cd85588327a6f19802717fcdfd