### PR TITLE
Add application modal for program and event details

### DIFF
--- a/frontend/src/app/details/EventDetails.tsx
+++ b/frontend/src/app/details/EventDetails.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import Image from 'next/image';
+import { useState } from 'react';
 import styles from './Details.module.css';
 
 import type { EventApi } from '@/types';
 import LinkIcon from '@/components/icons/LinkIcon/LinkIcon';
+import Modal from '@/components/ui/Modal/Modal';
+import api from '@/lib/api';
 
 export default function EventDetails({
   data,
@@ -13,6 +16,18 @@ export default function EventDetails({
   data: EventApi;
   onBack: () => void;
 }) {
+  const [showModal, setShowModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    try {
+      await api.post('/applications', { eventId: data.id });
+      setShowModal(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
   return (
     <>
       <div className={`${styles.header} container`}>
@@ -67,7 +82,22 @@ export default function EventDetails({
             </div>
           )}
         </div>
-        <button className='button-large'>Записаться</button>
+        <button className='button-large' onClick={() => setShowModal(true)}>
+          Записаться
+        </button>
+        {showModal && (
+          <Modal onClose={() => setShowModal(false)}>
+            <p>Вы хотите записаться:</p>
+            <p className='font-body-normal-bold'>{data.title}</p>
+            <button
+              className='button-large'
+              onClick={handleConfirm}
+              disabled={isSubmitting}
+            >
+              Подтвердить запись
+            </button>
+          </Modal>
+        )}
       </div>
     </>
   );

--- a/frontend/src/app/details/ProgramDetails.tsx
+++ b/frontend/src/app/details/ProgramDetails.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import Image from 'next/image';
+import { useState } from 'react';
 import { ProgramDocument, ProgramFormat, ProgramLevel } from '@prisma/client';
 
 import type { ProgramApi } from '@/types';
 import AccordionBlock from '@/components/ui/AccordionBlock/AccordionBlock';
 import LinkIcon from '@/components/icons/LinkIcon/LinkIcon';
+import Modal from '@/components/ui/Modal/Modal';
+import api from '@/lib/api';
 import styles from './Details.module.css';
 
 export default function ProgramDetails({
@@ -34,6 +37,19 @@ export default function ProgramDetails({
     [ProgramFormat.OFFLINE]: 'очный',
     [ProgramFormat.ONLINE]: 'онлайн',
   };
+
+  const [showModal, setShowModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    try {
+      await api.post('/applications', { programId: data.id });
+      setShowModal(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
   return (
     <>
@@ -113,7 +129,22 @@ export default function ProgramDetails({
             </ul>
           </AccordionBlock>
         </div>
-        <button className='button-large'>Записаться</button>
+        <button className='button-large' onClick={() => setShowModal(true)}>
+          Записаться
+        </button>
+        {showModal && (
+          <Modal onClose={() => setShowModal(false)}>
+            <p>Вы хотите записаться:</p>
+            <p className='font-body-normal-bold'>{data.title}</p>
+            <button
+              className='button-large'
+              onClick={handleConfirm}
+              disabled={isSubmitting}
+            >
+              Подтвердить запись
+            </button>
+          </Modal>
+        )}
       </div>
     </>
   );

--- a/frontend/src/components/ui/Modal/Modal.module.css
+++ b/frontend/src/components/ui/Modal/Modal.module.css
@@ -1,0 +1,24 @@
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: white;
+  padding: 24px;
+  border-radius: var(--radius-large);
+  max-width: 300px;
+  width: calc(100% - 40px);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/frontend/src/components/ui/Modal/Modal.tsx
+++ b/frontend/src/components/ui/Modal/Modal.tsx
@@ -1,0 +1,18 @@
+'use client';
+import React from 'react';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Modal component
- hook up modal in ProgramDetails and EventDetails to create applications

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684868e6f00883279d8e992229641c63