### PR TITLE
Implement proxy helper for API routes

### DIFF
--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,20 +1,4 @@
-import { NextResponse } from 'next/server';
-
+import { proxy } from '@/app/api/proxy';
 export async function POST(req: Request) {
-  const body = await req.json();
-  const nest = await fetch(`${process.env.NEXT_PUBLIC_BACKEND}/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    credentials: 'include',
-  });
-
-  const data = await nest.json();
-  const res = NextResponse.json(data, { status: nest.status });
-
-  nest.headers.forEach((v, k) => {
-    if (k.toLowerCase() === 'set-cookie') res.headers.append('set-cookie', v);
-  });
-
-  return res;
+  return proxy(req, `${process.env.NEXT_PUBLIC_BACKEND}/auth/login`);
 }

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,17 +1,5 @@
-import { NextResponse } from 'next/server';
+import { proxy } from '@/app/api/proxy';
 
-export async function POST() {
-  const nest = await fetch(`${process.env.NEXT_PUBLIC_BACKEND}/auth/logout`, {
-    method: 'POST',
-    credentials: 'include', // ← передаём cookie
-  });
-
-  const res = NextResponse.json(await nest.json(), { status: nest.status });
-
-  // пробрасываем Set-Cookie (clearCookie) из Nest
-  nest.headers.forEach((v, k) => {
-    if (k.toLowerCase() === 'set-cookie') res.headers.append('set-cookie', v);
-  });
-
-  return res;
+export async function POST(req: Request) {
+  return proxy(req, `${process.env.NEXT_PUBLIC_BACKEND}/auth/logout`);
 }

--- a/frontend/src/app/api/auth/refresh/route.ts
+++ b/frontend/src/app/api/auth/refresh/route.ts
@@ -1,19 +1,5 @@
-import { NextResponse } from 'next/server';
+import { proxy } from '@/app/api/proxy';
 
-export async function POST() {
-  /* проксируем в Nest */
-  const nest = await fetch(`${process.env.NEXT_PUBLIC_BACKEND}/auth/refresh`, {
-    method: 'POST',
-    credentials: 'include',
-  });
-
-  const body = await nest.json();
-  const res = NextResponse.json(body, { status: nest.status });
-
-  /* пробрасываем Set-Cookie из Nest → браузеру */
-  nest.headers.forEach((v, k) => {
-    if (k.toLowerCase() === 'set-cookie') res.headers.append('set-cookie', v);
-  });
-
-  return res;
+export async function POST(req: Request) {
+  return proxy(req, `${process.env.NEXT_PUBLIC_BACKEND}/auth/refresh`);
 }

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,22 +1,7 @@
-import { NextResponse } from 'next/server';
+import { proxy } from '@/app/api/proxy';
 
 // FIXME: чето с этим сделать
 
 export async function POST(req: Request) {
-  const body = await req.json();
-  const nest = await fetch(`${process.env.NEXT_PUBLIC_BACKEND}/auth/register`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    credentials: 'include',
-  });
-
-  const data = await nest.json();
-  const res = NextResponse.json(data, { status: nest.status });
-
-  nest.headers.forEach((v, k) => {
-    if (k.toLowerCase() === 'set-cookie') res.headers.append('set-cookie', v);
-  });
-
-  return res;
+  return proxy(req, `${process.env.NEXT_PUBLIC_BACKEND}/auth/register`);
 }

--- a/frontend/src/app/api/proxy.ts
+++ b/frontend/src/app/api/proxy.ts
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function proxy(req: Request, targetUrl: string) {
+  const init: RequestInit = {
+    method: req.method,
+    credentials: 'include',
+    headers: {},
+  };
+
+  const contentType = req.headers.get('content-type');
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    if (contentType?.includes('application/json')) {
+      const json = await req.json();
+      (init.headers as Record<string, string>)['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(json);
+    } else {
+      const text = await req.text();
+      if (text) {
+        init.body = text;
+      }
+      if (contentType) {
+        (init.headers as Record<string, string>)['Content-Type'] = contentType;
+      }
+    }
+  }
+
+  const access = cookies().get('accessToken')?.value;
+  if (access) {
+    (init.headers as Record<string, string>)['Authorization'] = `Bearer ${access}`;
+  }
+
+  const nest = await fetch(targetUrl, init);
+  const data = await nest.json();
+  const res = NextResponse.json(data, { status: nest.status });
+
+  nest.headers.forEach((v, k) => {
+    if (k.toLowerCase() === 'set-cookie') res.headers.append('set-cookie', v);
+  });
+
+  return res;
+}

--- a/frontend/src/app/api/users/me/route.ts
+++ b/frontend/src/app/api/users/me/route.ts
@@ -1,20 +1,20 @@
-import { cookies } from 'next/headers';
+import { proxy } from '@/app/api/proxy';
 import { NextResponse } from 'next/server';
 
-export async function GET() {
-  const access = (await cookies()).get('accessToken')?.value;
-  if (!access) return NextResponse.json({}, { status: 401 });
+export async function GET(req: Request) {
+  const res = await proxy(req, `${process.env.NEXT_PUBLIC_BACKEND}/users/me`);
 
-  const nestRes = await fetch(`${process.env.NEXT_PUBLIC_BACKEND}/users/me`, {
-    headers: { Authorization: `Bearer ${access}` },
-  });
-
-  if (!nestRes.ok) {
-    return NextResponse.json(await nestRes.json(), { status: nestRes.status });
+  if (!res.ok) {
+    return res;
   }
 
-  const user = await nestRes.json();
+  const user = await res.json();
   const role = user.roles?.[0]?.name ?? null;
 
-  return NextResponse.json({ role, user });
+  const next = NextResponse.json({ role, user }, { status: res.status });
+  res.headers.forEach((v, k) => {
+    if (k.toLowerCase() === 'set-cookie') next.headers.append('set-cookie', v);
+  });
+
+  return next;
 }


### PR DESCRIPTION
## Summary
- add `proxy` helper to centralize API proxying
- use the helper in auth routes and `users/me`

## Testing
- `npm run lint --workspace frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8dc95134832782dff1211a63e354