### PR TITLE
Add DTO for applications with validation

### DIFF
--- a/backend/src/applications/applications.controller.ts
+++ b/backend/src/applications/applications.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { ApplicationsService } from './applications.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreateApplicationDto } from './dto/create-application.dto';
 
 @Controller('applications')
 @UseGuards(JwtAuthGuard)
@@ -17,7 +18,7 @@ export class ApplicationsController {
   constructor(private service: ApplicationsService) {}
 
   @Post()
-  create(@Body() dto: any, @Req() req) {
+  create(@Body() dto: CreateApplicationDto, @Req() req) {
     return this.service.create({
       ...dto,
       userId: req.user.userId,

--- a/backend/src/applications/dto/create-application.dto.ts
+++ b/backend/src/applications/dto/create-application.dto.ts
@@ -1,0 +1,51 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidateIf,
+  IsString,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'onlyOne', async: false })
+class OnlyOneConstraint implements ValidatorConstraintInterface {
+  validate(_value: any, args: ValidationArguments) {
+    const obj = args.object as any;
+    const [relatedPropertyName] = args.constraints;
+    const relatedValue = obj[relatedPropertyName];
+    const value = (obj as any)[args.property];
+    const hasCurrent = value !== undefined && value !== null && value !== '';
+    const hasRelated = relatedValue !== undefined && relatedValue !== null && relatedValue !== '';
+    return (hasCurrent || hasRelated) && !(hasCurrent && hasRelated);
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const [relatedPropertyName] = args.constraints;
+    return `Either ${args.property} or ${relatedPropertyName} must be provided, but not both`;
+  }
+}
+
+function OnlyOne(property: string, validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      constraints: [property],
+      options: validationOptions,
+      validator: OnlyOneConstraint,
+    });
+  };
+}
+
+export class CreateApplicationDto {
+  @OnlyOne('eventId')
+  @ValidateIf(o => o.programId !== undefined)
+  @IsString()
+  programId?: string;
+
+  @OnlyOne('programId')
+  @ValidateIf(o => o.eventId !== undefined)
+  @IsString()
+  eventId?: string;
+}


### PR DESCRIPTION
## Summary
- create `CreateApplicationDto` to validate programId/eventId
- update controller to use the new DTO
- global ValidationPipe already checks incoming DTOs

## Testing
- `npx tsc -p backend/tsconfig.build.json` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_684d8d4896b083278e34a38491e4bbfd