### PR TITLE
Refactor auth api handling

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,12 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import {
+  login as apiLogin,
+  register as apiRegister,
+  logout as apiLogout,
+  getMe,
+} from '@/services/authService';
 
 // FIXME: какой-то странный контекст на все, наверное декомпозировать
 
@@ -31,31 +37,19 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   /* 1. при монтировании пытаемся получить роль */
   useEffect(() => {
     (async () => {
-      const res = await fetch('/api/users/me', {
-        credentials: 'include', // важно, чтобы сервер мог прочитать куки
-      });
-      const { role } = await res.json();
-      setRole(role);
+      const me = await getMe();
+      setRole(me?.role ?? null);
     })();
   }, []);
 
   /* 2. login: отправляем форму, куки ставятся сервером,
         затем ещё раз запрашиваем /me */
   const login = async (email: string, password: string) => {
-    const res = await fetch('/api/auth/login', {
-      method: 'POST',
-      credentials: 'include', // важно, чтобы Set-Cookie сработал
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-
-    if (!res.ok) throw new Error('Неверные данные');
-
-    // куки уже в браузере, просто узнаём роль
-    const me = await fetch('/api/users/me', { credentials: 'include' });
-    if (me.ok) {
-      const { role } = await me.json();
-      setRole(role);
+    try {
+      const me = await apiLogin(email, password);
+      setRole(me?.role ?? null);
+    } catch {
+      throw new Error('Неверные данные');
     }
   };
 
@@ -65,24 +59,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     email: string,
     password: string
   ) => {
-    const res = await fetch('/api/auth/register', {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ fullName, phone, email, password }),
-    });
-
-    if (!res.ok) {
-      const { message } = await res.json().catch(() => ({}));
-      throw new Error(message ?? 'REGISTER_FAILED');
+    try {
+      const me = await apiRegister(fullName, phone, email, password);
+      setRole(me?.role ?? null);
+    } catch (err: any) {
+      throw new Error(err?.response?.data?.message ?? 'REGISTER_FAILED');
     }
-
-    await login(email, password);
   };
 
   /* 3. logout: бек удаляет куки, затем сбрасываем роль */
   const logout = async () => {
-    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    await apiLogout();
     setRole(null);
   };
 

--- a/frontend/src/lib/apiPublic.ts
+++ b/frontend/src/lib/apiPublic.ts
@@ -1,6 +1,0 @@
-import axios from 'axios';
-
-export const apiPublic = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BACKEND,
-  withCredentials: true,
-});

--- a/frontend/src/lib/getMe.ts
+++ b/frontend/src/lib/getMe.ts
@@ -1,15 +1,5 @@
+import { getMe as fetchMe } from '@/services/authService';
+
 export async function getMe() {
-  try {
-    const res = await fetch('/api/users/me', {
-      credentials: 'include',
-      cache: 'no-store',
-    });
-
-    if (res.status === 401) return null; // гость
-    if (!res.ok) throw new Error('failed');
-
-    return (await res.json()) as { role: string | null; user: any };
-  } catch {
-    return null; // сеть упала -> считаем гостем
-  }
+  return fetchMe();
 }

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,0 +1,29 @@
+import api from '@/lib/api';
+
+export async function login(email: string, password: string) {
+  await api.post('/auth/login', { email, password });
+  return getMe();
+}
+
+export async function register(
+  fullName: string,
+  phone: string,
+  email: string,
+  password: string
+) {
+  await api.post('/auth/register', { fullName, phone, email, password });
+  return login(email, password);
+}
+
+export async function logout() {
+  await api.post('/auth/logout');
+}
+
+export async function getMe() {
+  try {
+    const { data } = await api.get('/users/me');
+    return data as { role: string | null; user: any };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize all auth-related network logic in `authService`
- update `AuthContext` and `getMe` to use the new service
- remove unused `apiPublic.ts`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540ff2c2948327b647e31d584f2f78